### PR TITLE
Add currency, amount and is_recurring_start to the payment status information

### DIFF
--- a/src/models/m_payment.erl
+++ b/src/models/m_payment.erl
@@ -87,11 +87,10 @@ m_get([ <<"status">>, PaymentNr | Rest ], _Msg, Context) when is_binary(PaymentN
                 orelse z_acl:rsc_editable(UserId, Context)
             of
                 true ->
-                    Status = #{
-                        <<"is_paid">> => maps:get(<<"is_paid">>, Payment),
-                        <<"is_failed">> => maps:get(<<"is_failed">>, Payment),
-                        <<"status">> => maps:get(<<"status">>, Payment)
-                    },
+                    Status = maps:with([ <<"status">>, <<"is_paid">>, <<"is_failed">>,
+                                         <<"is_recurring_start">>,
+                                         <<"currency">>, <<"amount">> ],
+                                        Payment),
                     {ok, {Status, Rest}};
                 false ->
                     {error, eacces}


### PR DESCRIPTION
The status information did not include information if a payment was the start of a recurring payment. To give good feedback it is also handy to have the amount and currency of the payment. 