### PR TITLE
Map enoent to notfound and some dialyzer fixes

### DIFF
--- a/src/models/m_payment_log.erl
+++ b/src/models/m_payment_log.erl
@@ -25,11 +25,12 @@
 
 -include_lib("zotonic_core/include/zotonic.hrl").
 
--spec log(PaymentId, Event, Props, Context) -> {ok, integer()}
-    when PaymentId :: integer(),
-         Event :: binary() | atom() | string(),
-         Props :: map() | proplists:proplist(),
-         Context :: z:context().
+-spec log(PaymentId, Event, Props, Context) -> Result when 
+      PaymentId :: integer(),
+      Event :: binary() | atom() | string(),
+      Props :: map() | proplists:proplist(),
+      Context :: z:context(),
+      Result :: {ok, integer() | undefined} | {error, term()}.
 log(PaymentId, Event, Props, Context) when is_list(Props) ->
     Ps1 = [ {z_convert:to_binary(K), V} || {K, V} <- Props ],
     log(PaymentId, Event, maps:from_list(Ps1), Context);

--- a/src/support/payment_export.erl
+++ b/src/support/payment_export.erl
@@ -46,8 +46,9 @@ headers() ->
         country
     ].
 
+-spec data(z:context()) -> {ok, list()}.
 data(Context) ->
-    #search_result{result = Result} = z_search:search(payments, {1, 100000}, Context),
+    #search_result{result = Result} = z_search:search({<<"payments">>, #{}}, {1, 100000}, Context),
     {ok, Result}.
 
 values(Item, Context) ->


### PR DESCRIPTION
Map `enoent` to `notfound` for get and get_by_psp.

Fixed a couple of other dialyzer errors. 